### PR TITLE
Fixing initialZoomScaleWithMinScale when image is larger than the screen

### DIFF
--- a/ios/RNPhotoView.m
+++ b/ios/RNPhotoView.m
@@ -140,6 +140,7 @@
 #pragma mark - Setup
 
 - (CGFloat)initialZoomScaleWithMinScale {
+    CGFloat minZoom = self.minimumZoomScale;
     CGFloat zoomScale = self.minimumZoomScale;
     if (_photoImageView) {
         // Zoom image to fill if the aspect ratios are fairly similar
@@ -153,7 +154,7 @@
         if (ABS(boundsAR - imageAR) < 0.17) {
             zoomScale = MAX(xScale, yScale);
             // Ensure we don't zoom in or out too far, just in case
-            zoomScale = MIN(MAX(self.minimumZoomScale, zoomScale), self.maximumZoomScale);
+            zoomScale = MIN(MAX(minZoom, zoomScale), minZoom);
         }
     }
     return zoomScale;


### PR DESCRIPTION
https://github.com/alwx/react-native-photo-view/pull/86

For some reason, when the image is too large, it does not open in fit mode. #38

During the debug I realize that the value of self.minimumZoomScale is not consistent during the calculation. Storing this value in a variable solved the problem.